### PR TITLE
Basic TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+declare module "json-deep-copy" {
+  export interface JsonObject {
+    [key: string]: JsonValue;
+  }
+
+  export interface JsonArray extends Array<JsonValue> {}
+
+  export type JsonValue = boolean | number | string | null | JsonArray | JsonObject;
+
+  export default function deepCopy<T extends JsonValue>(src: T): T;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,3 @@
 declare module "json-deep-copy" {
-  export interface JsonObject {
-    [key: string]: JsonValue;
-  }
-
-  export interface JsonArray extends Array<JsonValue> {}
-
-  export type JsonValue = boolean | number | string | null | JsonArray | JsonObject;
-
-  export default function deepCopy<T extends JsonValue>(src: T): T;
+  export default function deepCopy<T>(src: T): T;
 }


### PR DESCRIPTION
Nothing fancy, but at least allows something like this without error:

```ts
import deepCopy from "json-deep-copy";

interface Person {
  name: string;
}

let people: Person[] = [];

const person: Person = { name: "Rasmus" };

const copy = deepCopy(person); // typeof(copy) is Person ✔

people.push(copy); // type-checks ✔
```

Unfortunately, the input value to `deepCopy` isn't type-checked - I would have like to submit proper typings for that, but it [doesn't look possible](https://github.com/mindplay-dk/deep-copy/commit/f52b6224569e1a3d528fe557375b9ea7abaa256a) with what we have in TS yet.
